### PR TITLE
Fix incorrect theta values when atan returns the wrong quadrant

### DIFF
--- a/src/convert.py
+++ b/src/convert.py
@@ -20,9 +20,21 @@ class Convert:
       return self.coordinate
     if isinstance(self.coordinate, Cartesian3D):
       magnitude = math.sqrt(self.coordinate.x**2 + self.coordinate.y**2 + self.coordinate.z**2)
+      atan_theta = math.degrees(math.atan(self.coordinate.y / self.coordinate.x))
+      # Since arctan only ever returns between -90 and 90 degrees, we need to use our knowledge
+      # of geometry to "translate" the angle correctly
+      if self.coordinate.x >= 0:
+        theta = atan_theta
+      elif self.coordinate.x < 0:
+        theta = atan_theta + 180
+
+      if theta < 0:
+        # Always return a positive value for degrees
+        theta = theta + 360
+
       return Spherical(
           rho=magnitude,
-          theta=math.degrees(math.atan(self.coordinate.y / self.coordinate.x)),
+          theta=theta,
           phi=math.degrees(math.acos(self.coordinate.z / magnitude))
         )
 

--- a/tests/test_Spherical.py
+++ b/tests/test_Spherical.py
@@ -83,6 +83,42 @@ class TestSpherical(unittest.TestCase):
     self.assertAlmostEqual(expected.theta, result.theta, places=3)
     self.assertAlmostEqual(expected.phi, result.phi, places=3)
 
+  def test_convert_fromCartesian3D_second_quadrant(self):
+    """
+    Test that converting from Cartesian3D with a negative x value and a positive y value
+    to Spherical returns correctly
+    """
+    val = Cartesian3D(-1, 1, 1)
+    expected = Spherical(math.sqrt(3), 135.0000, 54.7356)
+    result = Convert(val).toSpherical()
+    self.assertAlmostEqual(expected.rho, result.rho, places=3)
+    self.assertAlmostEqual(expected.theta, result.theta, places=3)
+    self.assertAlmostEqual(expected.phi, result.phi, places=3)
+
+  def test_convert_fromCartesian3D_third_quadrant(self):
+    """
+    Test that converting from Cartesian3D with a negative x value and a negative y value
+    to Spherical returns correctly
+    """
+    val = Cartesian3D(-1, -1, 1)
+    expected = Spherical(math.sqrt(3), 225.0000, 54.7356)
+    result = Convert(val).toSpherical()
+    self.assertAlmostEqual(expected.rho, result.rho, places=3)
+    self.assertAlmostEqual(expected.theta, result.theta, places=3)
+    self.assertAlmostEqual(expected.phi, result.phi, places=3)
+
+  def test_convert_fromCartesian3D_fourth_quadrant(self):
+    """
+    Test that converting from Cartesian3D with a positive x value and a negative y value
+    to Spherical returns correctly
+    """
+    val = Cartesian3D(1, -1, 1)
+    expected = Spherical(math.sqrt(3), 315.0000, 54.7356)
+    result = Convert(val).toSpherical()
+    self.assertAlmostEqual(expected.rho, result.rho, places=3)
+    self.assertAlmostEqual(expected.theta, result.theta, places=3)
+    self.assertAlmostEqual(expected.phi, result.phi, places=3)
+
   def test_convert_fromPolar(self):
     """
     Test that converting from Polar to Spherical correctly returns an error


### PR DESCRIPTION
# Summary
atan is defined to return a value between -90 and 90 degrees, thus when converting values in the second or third quadrant the angle would be pointing the wrong direction.

Offset the angle by 180 degrees when working in the second or third quadrants (with negative x values) to ensure the angle is correct. Also convert negative angles to positive angles to line up with how I like to think.

## Test Plan
Tests included which test all four quadrants to ensure the returned angle is correct.