### PR TITLE
Fix pylint complaints for src/rotate.py

### DIFF
--- a/coordinatetoolbox.py
+++ b/coordinatetoolbox.py
@@ -82,11 +82,11 @@ def main():
 
   rotated = None
   if args.axis == 'x':
-    rotated = Rotate(input_coordinate).aboutXAxis(args.rotation)
+    rotated = Rotate(input_coordinate).about_x_axis(args.rotation)
   if args.axis == 'y':
-    rotated = Rotate(input_coordinate).aboutYAxis(args.rotation)
+    rotated = Rotate(input_coordinate).about_y_axis(args.rotation)
   if args.axis == 'z':
-    rotated = Rotate(input_coordinate).aboutZAxis(args.rotation)
+    rotated = Rotate(input_coordinate).about_z_axis(args.rotation)
 
   output = None
   if args.output_system == 'cartesian3D':

--- a/src/rotate.py
+++ b/src/rotate.py
@@ -67,7 +67,7 @@ class Rotate:
 
     # Now convert that output back to what the user actually wanted to rotate
     if isinstance(self.coordinate, Spherical):
-      return Convert(retval).toSpherical();
+      return Convert(retval).toSpherical()
     if isinstance(self.coordinate, Cartesian3D):
-      return Convert(retval).toCartesian3D();
-    raise NotImplementedError("Not prepared to rotate a {type}".format(self.coordinate.__class__.__name__));
+      return Convert(retval).toCartesian3D()
+    raise NotImplementedError("Not prepared to rotate a {type}".format(self.coordinate.__class__.__name__))

--- a/src/rotate.py
+++ b/src/rotate.py
@@ -61,8 +61,8 @@ class Rotate:
       The angle (in degrees) to rotate
     """
     rotvec = R.from_rotvec(math.radians(rotation) * np.array(aboutvec))
-    input = Convert(self.coordinate).toCartesian3D()
-    outvec = rotvec.apply(input)
+    invec = Convert(self.coordinate).toCartesian3D()
+    outvec = rotvec.apply(invec)
     retval = Cartesian3D(outvec[0], outvec[1], outvec[2])
 
     # Now convert that output back to what the user actually wanted to rotate

--- a/src/rotate.py
+++ b/src/rotate.py
@@ -6,11 +6,10 @@ Operator class for various rotations on the given coordinate
 """
 
 import math
-import numpy as np
-import scipy as sp
-from scipy.spatial.transform import Rotation as R
-
 from typing import Tuple
+
+import numpy as np
+from scipy.spatial.transform import Rotation as R
 
 from .convert import Convert
 from .coordinates import Coordinate

--- a/src/rotate.py
+++ b/src/rotate.py
@@ -24,34 +24,34 @@ class Rotate:
   def __init__(self, coordinate: Coordinate):
     self.coordinate = coordinate
 
-  def aboutXAxis(self, rotation: float) -> Coordinate:
+  def about_x_axis(self, rotation: float) -> Coordinate:
     """
     Rotate the input coordinate a given number of degrees around the X axis
 
     rotation: float
       The angle (in degrees) to rotate
     """
-    return self.aboutVector(aboutvec=[1, 0, 0], rotation=rotation)
+    return self.about_vector(aboutvec=[1, 0, 0], rotation=rotation)
 
-  def aboutYAxis(self, rotation: float) -> Coordinate:
+  def about_y_axis(self, rotation: float) -> Coordinate:
     """
     Rotate the input coordinate a given number of degrees around the Y axis
 
     rotation: float
       The angle (in degrees) to rotate
     """
-    return self.aboutVector(aboutvec=[0, 1, 0], rotation=rotation)
+    return self.about_vector(aboutvec=[0, 1, 0], rotation=rotation)
 
-  def aboutZAxis(self, rotation: float) -> Coordinate:
+  def about_z_axis(self, rotation: float) -> Coordinate:
     """
     Rotate the input coordinate a given number of degrees around the Z axis
 
     rotation: float
       The angle (in degrees) to rotate
     """
-    return self.aboutVector(aboutvec=[0, 0, 1], rotation=rotation)
+    return self.about_vector(aboutvec=[0, 0, 1], rotation=rotation)
 
-  def aboutVector(self, aboutvec: Tuple[float, float, float], rotation: float) -> Coordinate:
+  def about_vector(self, aboutvec: Tuple[float, float, float], rotation: float) -> Coordinate:
     """
     Rotate the input coordinate a given number of degrees around the given vector
 

--- a/src/rotate.py
+++ b/src/rotate.py
@@ -70,4 +70,4 @@ class Rotate:
       return Convert(retval).toSpherical()
     if isinstance(self.coordinate, Cartesian3D):
       return Convert(retval).toCartesian3D()
-    raise NotImplementedError("Not prepared to rotate a {type}".format(self.coordinate.__class__.__name__))
+    raise NotImplementedError("Not prepared to rotate a {type}".format(type=self.coordinate.__class__.__name__))

--- a/src/rotate.py
+++ b/src/rotate.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: 2021 Simon Redman <simon@ergotech.com>
 # SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 
+"""
+Operator class for various rotations on the given coordinate
+"""
+
 import math
 import numpy as np
 import scipy as sp

--- a/tests/test_Rotate.py
+++ b/tests/test_Rotate.py
@@ -25,7 +25,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(1, 0, 0)
     expected = Cartesian3D(1, 0, 0)
-    result = Rotate(val).aboutXAxis(90)
+    result = Rotate(val).about_x_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_xunit_yaxis(self):
@@ -34,7 +34,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(1, 0, 0)
     expected = Cartesian3D(0, 0, -1)
-    result = Rotate(val).aboutYAxis(90)
+    result = Rotate(val).about_y_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_xunit_zaxis(self):
@@ -43,7 +43,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(1, 0, 0)
     expected = Cartesian3D(0, 1, 0)
-    result = Rotate(val).aboutZAxis(90)
+    result = Rotate(val).about_z_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_yunit_xaxis(self):
@@ -52,7 +52,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(0, 1, 0)
     expected = Cartesian3D(0, 0, 1)
-    result = Rotate(val).aboutXAxis(90)
+    result = Rotate(val).about_x_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_neg_yunit_xaxis(self):
@@ -61,7 +61,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(0, -1, 0)
     expected = Cartesian3D(0, 0, -1)
-    result = Rotate(val).aboutXAxis(90)
+    result = Rotate(val).about_x_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_yunit_yaxis(self):
@@ -70,7 +70,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(0, 1, 0)
     expected = Cartesian3D(0, 1, 0)
-    result = Rotate(val).aboutYAxis(90)
+    result = Rotate(val).about_y_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_yunit_zaxis(self):
@@ -79,7 +79,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(0, 1, 0)
     expected = Cartesian3D(-1, 0, 0)
-    result = Rotate(val).aboutZAxis(90)
+    result = Rotate(val).about_z_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_zunit_xaxis(self):
@@ -88,7 +88,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(0, 0, 1)
     expected = Cartesian3D(0, -1, 0)
-    result = Rotate(val).aboutXAxis(90)
+    result = Rotate(val).about_x_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_zunit_yaxis(self):
@@ -97,7 +97,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(0, 0, 1)
     expected = Cartesian3D(1, 0, 0)
-    result = Rotate(val).aboutYAxis(90)
+    result = Rotate(val).about_y_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_zunit_zaxis(self):
@@ -106,7 +106,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(0, 0, 1)
     expected = Cartesian3D(0, 0, 1)
-    result = Rotate(val).aboutZAxis(90)
+    result = Rotate(val).about_z_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_idvec_xaxis(self):
@@ -115,7 +115,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(1, 1, 1)
     expected = Cartesian3D(1, -1, 1)
-    result = Rotate(val).aboutXAxis(90)
+    result = Rotate(val).about_x_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_idvec_yaxis(self):
@@ -124,7 +124,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(1, 1, 1)
     expected = Cartesian3D(1, 1, -1)
-    result = Rotate(val).aboutYAxis(90)
+    result = Rotate(val).about_y_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def test_rotate_idvec_zaxis(self):
@@ -133,7 +133,7 @@ class TestRotate(unittest.TestCase):
     """
     val = Cartesian3D(1, 1, 1)
     expected = Cartesian3D(-1, 1, 1)
-    result = Rotate(val).aboutZAxis(90)
+    result = Rotate(val).about_z_axis(90)
     self.fuzzyCompareCartesian3D(expected, result)
 
   def fuzzyCompareCartesian3D(self, val1: Cartesian3D, val2: Cartesian3D, places=3):


### PR DESCRIPTION
# Summary
Fix several pylint complaints for src/rotate.py:

- Add module docstring
- Clean up import
- Rename methods to snake casing
- Rename `input` variable to `invec`
- Remove unnecessary semicolons
- Use parameter name with str.format

## Test Plan
No functional changes, test pass